### PR TITLE
Fixes callback behaviour to mimic lambda more closely

### DIFF
--- a/lib/invoke/local.js
+++ b/lib/invoke/local.js
@@ -57,11 +57,7 @@ const invoke = (func, event, lambdaEndpoint, logger) => {
     try {
       const output = result.stdout ? JSON.parse(result.stdout) : null
 
-      if (!output) {
-        return BbPromise.reject(new Error('Error executing function'))
-      }
-
-      if (output.errorMessage) {
+      if (output && output.errorMessage !== null && output.errorMessage !== undefined) {
         return BbPromise.reject(new Error(output.errorMessage))
       }
 

--- a/lib/invoke/local.test.js
+++ b/lib/invoke/local.test.js
@@ -119,7 +119,7 @@ describe('local-invoke', () => {
     .then(handled => expect(handled).toEqual(true))
   })
 
-  it('should fail when stderr returned with no stdout', () => {
+  it('should not fail when stderr returned with no stdout', () => {
     const funcConfig = {
       runtime: 'node4.3',
       servicePath: '/test/path',
@@ -143,7 +143,7 @@ describe('local-invoke', () => {
 
     return lambda
     .invoke(funcConfig, event)
-    .catch((err) => {
+    .then((actual) => {
       expect(run.mock.calls.length).toBe(1)
       expect(run.mock.calls[0][0]).toEqual({
         addEnvVars: true,
@@ -166,11 +166,8 @@ describe('local-invoke', () => {
         ],
       })
 
-      expect(err.message).toEqual('Error executing function')
-
-      return true
+      expect(actual).toEqual(null)
     })
-    .then(handled => expect(handled).toEqual(true))
   })
 
   it('should fail when stdout has invalid json', () => {
@@ -225,5 +222,105 @@ describe('local-invoke', () => {
       return true
     })
     .then(handled => expect(handled).toEqual(true))
+  })
+
+  it('should pass when no error or result have been returned', () => {
+    const funcConfig = {
+      runtime: 'node4.3',
+      servicePath: '/test/path',
+      handler: 'index.handler',
+      memorySize: 512,
+      timeout: 10,
+      region: 'us-east-1',
+      environment: {},
+      stage: 'test',
+      key: 'test-service-test-test-func',
+    }
+    const event = {}
+
+    const result = {}
+
+    run.mockImplementation(() => BbPromise.resolve(result))
+
+    const lambda = lambdaLocal('http://localhost:5001')
+
+    return lambda
+    .invoke(funcConfig, event)
+    .then((actual) => {
+      expect(run.mock.calls.length).toBe(1)
+      expect(run.mock.calls[0][0]).toEqual({
+        addEnvVars: true,
+        handler: funcConfig.handler,
+        event,
+        taskDir: funcConfig.servicePath,
+        cleanUp: true,
+        returnSpawnResult: true,
+        dockerImage: 'lambci/lambda:node4.3',
+        dockerArgs: [
+          '-m', '512M',
+          '-e', 'AWS_LAMBDA_FUNCTION_NAME=test-service-test-test-func',
+          '-e', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE=512',
+          '-e', 'AWS_LAMBDA_FUNCTION_TIMEOUT=10',
+          '-e', 'AWS_LAMBDA_LOG_GROUP_NAME=/aws/lambda/test-service-test-test-func',
+          '-e', 'AWS_REGION=us-east-1',
+          '-e', 'SERVERLESS_SIMULATE=true',
+          '-e', 'SERVERLESS_SIMULATE_STAGE=test',
+          '-e', 'SERVERLESS_SIMULATE_LAMBDA_ENDPOINT=http://localhost:5001',
+        ],
+      })
+
+      expect(actual).toEqual(null)
+    })
+  })
+
+  it('should pass when error is null and no result passed', () => {
+    const funcConfig = {
+      runtime: 'node4.3',
+      servicePath: '/test/path',
+      handler: 'index.handler',
+      memorySize: 512,
+      timeout: 10,
+      region: 'us-east-1',
+      environment: {},
+      stage: 'test',
+      key: 'test-service-test-test-func',
+    }
+    const event = {}
+
+    const result = {
+      errorMessage: null,
+    }
+
+    run.mockImplementation(() => BbPromise.resolve(result))
+
+    const lambda = lambdaLocal('http://localhost:5001')
+
+    return lambda
+    .invoke(funcConfig, event)
+    .then((actual) => {
+      expect(run.mock.calls.length).toBe(1)
+      expect(run.mock.calls[0][0]).toEqual({
+        addEnvVars: true,
+        handler: funcConfig.handler,
+        event,
+        taskDir: funcConfig.servicePath,
+        cleanUp: true,
+        returnSpawnResult: true,
+        dockerImage: 'lambci/lambda:node4.3',
+        dockerArgs: [
+          '-m', '512M',
+          '-e', 'AWS_LAMBDA_FUNCTION_NAME=test-service-test-test-func',
+          '-e', 'AWS_LAMBDA_FUNCTION_MEMORY_SIZE=512',
+          '-e', 'AWS_LAMBDA_FUNCTION_TIMEOUT=10',
+          '-e', 'AWS_LAMBDA_LOG_GROUP_NAME=/aws/lambda/test-service-test-test-func',
+          '-e', 'AWS_REGION=us-east-1',
+          '-e', 'SERVERLESS_SIMULATE=true',
+          '-e', 'SERVERLESS_SIMULATE_STAGE=test',
+          '-e', 'SERVERLESS_SIMULATE_LAMBDA_ENDPOINT=http://localhost:5001',
+        ],
+      })
+
+      expect(actual).toEqual(null)
+    })
   })
 })


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/gertjvr/serverless-plugin-simulate/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Adjusted `local.js` to behave more like you would expect Lambda to behave as per the [AWS documentation](http://docs.aws.amazon.com/lambda/latest/dg/nodejs-prog-model-handler.html) which says:

```
callback();     // Indicates success but no information returned to the caller.
callback(null); // Indicates success but no information returned to the caller.
callback(null, "success");  // Indicates success with information returned to the caller.
callback(error);    //  Indicates error with error information returned to the caller.
```

Closes #34 
## How did you implement it:

Removed a line which checked whether the parsed `stdout` output was null and then forcefully errored even though that's actually a valid success output for lambda.

Adjusted the callback error checking so it more explicitly checks that the error parameter is not `null` or `undefined`.

## How can we verify it:

I added and modified the `local.test.js` unit tests but you can also verify using this handler.
```
'use strict';

module.exports = function(event, context, cb) {
    cb();
    //cb(null);
    //cb(null, 'success');
    //cb('error');
};
```

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES