### PR TITLE
Fix/accept header bug

### DIFF
--- a/lib/integration/lambda.js
+++ b/lib/integration/lambda.js
@@ -5,9 +5,18 @@ const velocityRenderer = require('./velocity/renderer')
 
 const event = (req) => {
   const http = req.context.http
-  const contentType = req.get('Accept') || '*/*'
+  const contentTypeString = req.get('Accept') || '*/*'
 
-  const template = http.requestTemplates[contentType]
+  const contentTypes = contentTypeString.split(',')
+
+  let template = null
+
+  for (let i = 0; i < contentTypes.length; i++) {
+    template = http.requestTemplates[contentTypes[i].replace(' ', '')]
+    if (template) {
+      break
+    }
+  }
 
   if (!template) throw new Error('No veolicty template is set')
 

--- a/lib/integration/lambda.test.js
+++ b/lib/integration/lambda.test.js
@@ -5,6 +5,7 @@ const integration = require('./lambda')
 describe('lambda integration', () => {
   const headers = {
     'user-agent': 'test-user-agent',
+    Accept: 'application/json',
   }
   const req = {
     get: jest.fn().mockImplementation((key) => headers[key]),
@@ -79,6 +80,85 @@ describe('lambda integration', () => {
       }
 
       const actual = integration.event(req)
+
+      expect(actual).toEqual(expected)
+    })
+
+    it("should not fail when multiple 'accept' header options are provided", () => {
+      const acceptHeaders = {
+        Accept: 'application/json, text/html, */*',
+      }
+
+      const basicRequest = {
+        get: jest.fn().mockImplementation((key) => acceptHeaders[key]),
+        url: '/',
+        method: 'GET',
+        headers,
+        params: {},
+        query: {},
+        context: {
+          functionName: 'test-func',
+          region: 'us-east-1',
+          stage: 'test',
+          servicePath: '/test/file/path',
+          handler: 'index.endpoint',
+          memorySize: 512,
+          timeout: 3,
+          runtime: 'nodejs4.3',
+          environment: {},
+
+          http: {
+            integration: 'lambda-proxy',
+            path: '/test/path',
+            method: 'post',
+            cors: null,
+            authorizer: {
+              name: 'authorizer',
+              identitySource: 'method.request.header.Authorization',
+              function: {
+                environment: {},
+                functionName: 'authorizer',
+                handler: 'index.authorizer',
+                memorySize: 512,
+                region: 'us-east-1',
+                runtime: 'nodejs4.3',
+                servicePath: '/test/file/path',
+                stage: 'test',
+                timeout: 3,
+              },
+            },
+            requestTemplates: {
+              '*/*': '$input.json(\'$\')',
+              'application/json': '$input.json(\'$\')',
+            },
+            responseMappings: [{
+              statusCode: 200,
+              pattern: '',
+              parameters: {},
+              template: '',
+            }, {
+              statusCode: 400,
+              pattern: '.*\\[400\\].*',
+              parameters: {},
+              template: '',
+            }],
+          },
+        },
+        connection: {
+          remoteAddress: '127.0.0.1',
+        },
+        body: {
+          hello: 'world',
+        },
+        user: {
+          principalId: '12345',
+        },
+      }
+      const expected = {
+        hello: 'world',
+      }
+
+      const actual = integration.event(basicRequest)
 
       expect(actual).toEqual(expected)
     })


### PR DESCRIPTION
## What did you implement:

Fixes the bug in lambda integration which fails when multiple `accept` options are provided in the request (eg. `application/json, text/html, */*`).

Closes #38 

## How did you implement it:

Changed the lambda integration logic to split the `accept` header into the separate options and then loop through them to check for request templates. Obviously this could be done in a more http `accept` compliant way in the future as `accept` can technically contain explicit ordering of return content types.

## How can we verify it:

***Manual Test***
* Create a test function which uses `integration: lambda` like the example below. 
* Run a request with the header `accept: application/json, text/html`

***Automated Test***
I have added a test to lib/integrations/lambda.test.js

## Todos:

- [x] Write tests
- [x] Write documentation
- [x] Fix linting errors
- [x] Provide verification config/commands/resources
- [x] Change ready for review message below


***Is this ready for review?:*** YES