### PR TITLE
content-type templating for incoming request

### DIFF
--- a/lib/integration/lambda.js
+++ b/lib/integration/lambda.js
@@ -5,7 +5,7 @@ const velocityRenderer = require('./velocity/renderer')
 
 const event = (req) => {
   const http = req.context.http
-  const contentTypeString = req.get('Accept') || '*/*'
+  const contentTypeString = req.get('Content-Type') || req.get('Accept') || '*/*'
 
   const contentTypes = contentTypeString.split(',')
 


### PR DESCRIPTION
shouldn't the input content-type determine the template to use?  I ran into this with a post of a text/csv but the response was expected to be a application/json result which caused it to try to parse the text/csv as a json file.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/gertjvr/serverless-plugin-simulate/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Changed content-type negotiation on request.

Related to https://github.com/gertjvr/serverless-plugin-simulate/issues/46.

## How did you implement it:

Just prepended content-type to the check list.

## How can we verify it:

In serverless.yml you can have:
          response:
            headers:
              Content-Type: "'application/json'"
          request:
            template:
              application/json: '{
                        "body" : $input.json(''$'')
                        }'
              text/csv:  '{
                        "body" : $input.body
                        }'

## Todos:

- [ ] Write tests
- [ ] Write documentation
- [ ] Fix linting errors
- [ ] Provide verification config/commands/resources
- [ ] Change ready for review message below

***Is this ready for review?:*** NO